### PR TITLE
Fix typo (Add missing 'be' in a 'may not be able' expression)

### DIFF
--- a/content/actions/hosting-your-own-runners/managing-self-hosted-runners/monitoring-and-troubleshooting-self-hosted-runners.md
+++ b/content/actions/hosting-your-own-runners/managing-self-hosted-runners/monitoring-and-troubleshooting-self-hosted-runners.md
@@ -310,7 +310,7 @@ If your build fails with the following error:
 Error: Input required and not supplied: java-version
 ```
 
-Check which Docker engine is installed on your self-hosted runner. To pass the inputs of an action into the Docker container, the runner uses environment variables that might contain dashes as part of their names. The action may not able to get the inputs if the Docker engine is not a binary executable, but is instead a shell wrapper or a link (for example, a Docker engine installed on Linux using `snap`). To address this error, configure your self-hosted runner to use a different Docker engine.
+Check which Docker engine is installed on your self-hosted runner. To pass the inputs of an action into the Docker container, the runner uses environment variables that might contain dashes as part of their names. The action may not be able to get the inputs if the Docker engine is not a binary executable, but is instead a shell wrapper or a link (for example, a Docker engine installed on Linux using `snap`). To address this error, configure your self-hosted runner to use a different Docker engine.
 
 To check if your Docker engine was installed using `snap`, use the `which` command. In the following example, the Docker engine was installed using `snap`:
 


### PR DESCRIPTION
Add missing 'be' in a 'may not be able' expression.

### Why:

A minor typo has been detected.

### What's being changed (if available, include any code snippets, screenshots, or gifs):

The typo is highlighted in the following screenshot:
![typo_highlight](https://github.com/cowuake/docs/assets/49900772/102fe5a4-7e14-4c01-8a3d-ee18336edc6f)
A 'be' is being added between 'not' and 'able'.

### Check off the following:

- [x] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline (this link will be available after opening the PR).

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [x] For content changes, I have completed the [self-review checklist](https://docs.github.com/en/contributing/collaborating-on-github-docs/self-review-checklist).
